### PR TITLE
Allow for parameters in the mock request.

### DIFF
--- a/lib/mockexpress.js
+++ b/lib/mockexpress.js
@@ -18,7 +18,7 @@ var MockExpress = function(route) {
 		'post': function() { router.post.apply(router, Array.prototype.slice.apply(arguments)); },
 		'use': function() { router.use.apply(router, Array.prototype.slice.apply(arguments)) },
 		'invoke': function(method, path, req, res, next) {
-			req = extend(req || defaultRequest || {}, { params: {} });
+			req = extend({ params: {} }, req || defaultRequest || {});
 			res = extend(res || defaultResponse || {}, {});
 
 			req.query = qs.parse(URL.parse(path).query);


### PR DESCRIPTION
The parameter order to extend in apply would replace any
parameters with a blank object instead of defaulting to a
blank object. This now allows for parameters to be specified
in the mock request.

Currently, the mock request that `makeRequest` provides
doesn't support parameters at all; however, I'm using `mock-express`
alongside `node-mocks-http`, which provides more featureful
mocked requests. That one does support parameters, but the
current behavior of `invoke` clears the parameters that you can
specify on it, thus breaking the other mock library and making
my mocking of a request with parameters impossible :)

Let me know if anything else needs to be done, or if I need to do
this differently to get it accepted!
