### PR TITLE
add res.send and res.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ Currently you have the following available to check
 * `sideEffects.viewName` - the view name passed as the first argument to `res.render`.
 * `sideEffects.model` - the model object passed as the second argument to `res.render`
 * `sideEffects.session` - anything that is set into the session object.
+* `sideEffects.json` - the variable passed as the first argument to `res.json`
+* `sideEffects.send` - the variable passed as the first argument to `res.send`

--- a/lib/mockexpress.js
+++ b/lib/mockexpress.js
@@ -68,6 +68,10 @@ var MockExpress = function(route) {
 			assert(typeof callback === 'function', 'makeResponse requires a valid callback function');
 
 			defaultResponse =  {
+				json: function(json) {
+					sideEffects.json = json;
+					callback(null, sideEffects);
+				},
 				redirect: function(location) {
 					sideEffects.redirect = location;
 					callback(null, sideEffects);
@@ -75,6 +79,10 @@ var MockExpress = function(route) {
 				render: function(viewName, model) {
 					sideEffects.viewName = viewName;
 					sideEffects.model = model;
+					callback(null, sideEffects);
+				},
+				send: function(body) {
+					sideEffects.send = body;
 					callback(null, sideEffects);
 				}
 			};

--- a/test/test.js
+++ b/test/test.js
@@ -148,6 +148,42 @@ describe('mockExpress', function() {
 		app.invoke('get', '/test/hello/world', myReq);
 	});
 
+	it('should return a body on res.send', function(done) {
+		var app = MockExpress();
+
+		app.get('/test/send', function (req, res) {
+			res.send('hello world');
+		});
+
+		var assertionCallback = app.makeAssertionCallback(done, function(err, sideEffects) {
+			assert.equal(sideEffects.send, 'hello world');
+		});
+
+		app.makeResponse(assertionCallback);
+
+		app.invoke('get', '/test/send');
+	});
+
+	it('should return json on res.json', function(done) {
+		var app = MockExpress();
+
+		app.get('/test/json', function (req, res) {
+			var content = {
+				hello: 'world'
+			};
+			
+			res.json(content);
+		});
+
+		var assertionCallback = app.makeAssertionCallback(done, function(err, sideEffects) {
+			assert.equal(sideEffects.json.hello, 'world');
+		});
+
+		app.makeResponse(assertionCallback);
+
+		app.invoke('get', '/test/json');
+	});
+
 	it ('should return / for path() if no route is specified', function() {
 		assert.equal(MockExpress().path(),'/');
 	});


### PR DESCRIPTION
Hi @masotime 

Adding `json` and `send` to default express responses. Please let me know if you have any questions or would like changes.

Thanks for a great module, very handy!
