### PR TITLE
npm audit fix && upgrade extend library due to security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "async": {
       "version": "1.0.0",
@@ -172,6 +173,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -306,7 +308,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "depd": {
       "version": "1.1.2",
@@ -467,9 +470,9 @@
       }
     },
     "extend": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
-      "integrity": "sha1-0VFvsP9WJNLr+RI+odrFoZlABPg="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extract-zip": {
       "version": "1.6.7",
@@ -488,7 +491,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "eyes": {
       "version": "0.1.8",
@@ -758,7 +762,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "jsbn": {
       "version": "0.1.1",
@@ -784,14 +789,6 @@
         "shelljs": "0.3.x",
         "strip-json-comments": "1.0.x",
         "unicode-5.2.0": "^0.7.5"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        }
       }
     },
     "json-schema": {
@@ -854,6 +851,12 @@
       "requires": {
         "graceful-fs": "^4.1.9"
       }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -1241,7 +1244,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "send": {
       "version": "0.16.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.16.3",
-    "extend": "^1.2.1"
+    "extend": "^3.0.2"
   },
   "devDependencies": {
     "mocha": "^5.2.0",


### PR DESCRIPTION
PR for fixing vulnerabilities with mock-express dependencies.

Edit: Link to the extend vulnerability:
https://www.npmjs.com/advisories/996